### PR TITLE
Test and Undeprecate "Optimal Savings II: LQ Techniques"

### DIFF
--- a/rst_files/perm_income_cons.rst
+++ b/rst_files/perm_income_cons.rst
@@ -31,26 +31,26 @@ For example, we saw how the model asserts that for any covariance stationary pro
 
 Other applications use the same LQ framework
 
-For example, a model isomorphic to the LQ permanent income model has been used by Robert Barro :cite:`Barro1979` to interpret intertemporal comovements of a government's tax collections, its  expenditures net of debt service, and its public debt 
+For example, a model isomorphic to the LQ permanent income model has been used by Robert Barro :cite:`Barro1979` to interpret intertemporal comovements of a government's tax collections, its  expenditures net of debt service, and its public debt
 
 This isomorphism means that in analyzing the LQ permanent income model, we are in effect also analyzing  the Barro tax smoothing model
 
 It is just a matter of appropriately relabeling the variables in Hall's model
 
-In this lecture, we'll 
+In this lecture, we'll
 
 * show how the solution to the LQ permanent income model can be obtained using LQ control methods
 
 * represent the model as a linear state space system as in :doc:`this lecture <linear_models>`
 
-* apply `QuantEcon <http://quantecon.org/julia_index.html>`__'s `LSS <https://github.com/QuantEcon/QuantEcon.jl/blob/master/src/lss.jl>`__ type to characterize statistical features of the consumer's optimal consumption and borrowing plans 
+* apply `QuantEcon <http://quantecon.org/julia_index.html>`__'s `LSS <https://github.com/QuantEcon/QuantEcon.jl/blob/master/src/lss.jl>`__ type to characterize statistical features of the consumer's optimal consumption and borrowing plans
 
-We'll then use these characterizations to construct a simple model of cross-section wealth and 
+We'll then use these characterizations to construct a simple model of cross-section wealth and
 consumption dynamics in the spirit of Truman Bewley :cite:`Bewley86`
 
 (Later we'll study other Bewley models---see :doc:`this lecture <aiyagari>`)
 
-The model will prove useful for illustrating concepts such as 
+The model will prove useful for illustrating concepts such as
 
 * stationarity
 
@@ -59,21 +59,18 @@ The model will prove useful for illustrating concepts such as
 * ensemble moments and cross section observations
 
 
- 
-
-
 Setup
 ======================
 
 
 Let's recall the basic features of the model  discussed in  :doc:`permanent income model<perm_income>`
 
-Consumer preferences are ordered  by 
+Consumer preferences are ordered  by
 
 .. math::
     :label: old1
 
-    E_0 \sum_{t=0}^\infty \beta^t u(c_t)  
+    E_0 \sum_{t=0}^\infty \beta^t u(c_t)
 
 
 where :math:`u(c) = -(c - \gamma)^2`
@@ -85,8 +82,8 @@ subject to the sequence of budget constraints
 .. math::
     :label: old2
 
-    c_t + b_t = \frac{1}{1 + r} b_{t+1}  + y_t, 
-    \quad t \geq 0  
+    c_t + b_t = \frac{1}{1 + r} b_{t+1}  + y_t,
+    \quad t \geq 0
 
 
 and the no-Ponzi condition
@@ -94,13 +91,13 @@ and the no-Ponzi condition
 .. math::
     :label: old42
 
-    E_0 \sum_{t=0}^\infty \beta^t b_t^2 < \infty  
+    E_0 \sum_{t=0}^\infty \beta^t b_t^2 < \infty
 
 
-The interpretation of all variables and parameters are the same as in the 
+The interpretation of all variables and parameters are the same as in the
 :doc:`previous lecture <perm_income>`
 
-We continue to assume that :math:`(1 + r) \beta = 1` 
+We continue to assume that :math:`(1 + r) \beta = 1`
 
 The dynamics of :math:`\{y_t\}` again follow the linear state space model
 
@@ -117,12 +114,10 @@ The dynamics of :math:`\{y_t\}` again follow the linear state space model
 The restrictions on the shock process and parameters are the same as in our :doc:`previous lecture <perm_income>`
 
 
-
-
 Digression on a useful isomorphism
 ----------------------------------
 
-The LQ permanent income model of consumption is mathematically isomorphic with a version of 
+The LQ permanent income model of consumption is mathematically isomorphic with a version of
 Barro's :cite:`Barro1979` model of tax smoothing.
 
 
@@ -130,7 +125,7 @@ In the LQ permanent income model
 
 * the household faces an exogenous process of nonfinancial income
 
-* the household wants to smooth consumption across states and time 
+* the household wants to smooth consumption across states and time
 
 In the Barro tax smoothing model
 
@@ -139,8 +134,7 @@ In the Barro tax smoothing model
 * a government wants to smooth tax collections across states and time
 
 
-
-If we set 
+If we set
 
 *  :math:`T_t`, total tax collections in Barro's model to consumption :math:`c_t` in the LQ permanent income model
 
@@ -152,7 +146,7 @@ If we set
 
 then the two models are mathematically equivalent
 
-All characterizations of a :math:`\{c_t, y_t, b_t\}` in the LQ permanent income model automatically apply to a :math:`\{T_t, G_t, B_t\}` process in the Barro model of tax smoothing  
+All characterizations of a :math:`\{c_t, y_t, b_t\}` in the LQ permanent income model automatically apply to a :math:`\{T_t, G_t, B_t\}` process in the Barro model of tax smoothing
 
 See :doc:`consumption and tax smoothing models <smoothing>` for further exploitation of an isomorphism between consumption and tax smoothing models
 
@@ -164,7 +158,7 @@ For the purposes of this lecture, let's assume :math:`\{y_t\}` is a second-order
 
 .. math::
 
-    y_{t+1} = \alpha + \rho_1 y_t + \rho_2 y_{t-1} + \sigma w_{t+1} 
+    y_{t+1} = \alpha + \rho_1 y_t + \rho_2 y_{t-1} + \sigma w_{t+1}
 
 
 We can map this into the linear state space framework in :eq:`sprob15ab2`, as
@@ -174,7 +168,7 @@ To do so we take
 
 .. math::
 
-    z_t = 
+    z_t =
     \begin{bmatrix}
         1 \\
         y_t \\
@@ -206,23 +200,21 @@ Here we solve the same model using :doc:`LQ methods <lqcontrol>` based on dynami
 After confirming that answers produced by the two methods agree, we apply `QuantEcon <http://quantecon.org/julia_index.html>`__'s `LSS <https://github.com/QuantEcon/QuantEcon.jl/blob/master/src/lss.jl>`__
 type to illustrate features of the model
 
-Why solve a model in two distinct ways? 
+Why solve a model in two distinct ways?
 
 Because by doing so we gather insights about the structure of the model
 
 Our earlier approach based on solving a system of expectational difference equations brought to the fore the role of the consumer's expectations about future nonfinancial income
 
-On the other hand, formulating the model in terms of an LQ dynamic programming problem reminds us that 
+On the other hand, formulating the model in terms of an LQ dynamic programming problem reminds us that
 
 - finding the state (of a dynamic programming problem) is an art, and
 
 - iterations on a Bellman equation  implicitly jointly solve both a  forecasting problem and a control problem
 
 
-
 The LQ Problem
 ---------------------------
-
 
 Recall from our :doc:`lecture on LQ theory <lqcontrol>` that the optimal linear regulator problem is to choose
 a decision rule for :math:`u_t` to minimize
@@ -239,7 +231,7 @@ subject to :math:`x_0` given and the law of motion
     :label: pilqsd
 
     x_{t+1} =  \tilde A x_t+ \tilde B u_t+ \tilde C w_{t+1},
-    \qquad t\geq 0, 
+    \qquad t\geq 0,
 
 
 where :math:`w_{t+1}` is iid with mean vector zero and :math:`\mathbb E w_t w'_t= I`
@@ -257,16 +249,14 @@ The optimal policy is :math:`u_t = -Fx_t`, where :math:`F := \beta (Q+\beta \til
 Under an optimal decision rule :math:`F`, the state vector :math:`x_t` evolves according to :math:`x_{t+1} = (\tilde A-\tilde BF) x_t + \tilde C w_{t+1}`
 
 
-
 Mapping into the LQ framework
 --------------------------------
 
-
-To map into the LQ framework, we'll use 
+To map into the LQ framework, we'll use
 
 .. math::
 
-    x_t := 
+    x_t :=
         \begin{bmatrix}
             z_t \\
             b_t
@@ -290,20 +280,20 @@ With this notation and :math:`U_\gamma := \begin{bmatrix} \gamma & 0 & 0
     \tilde A :=
          \begin{bmatrix}
             A  &  0 \\
-            (1 + r)(U_\gamma - U) & 1 + r 
+            (1 + r)(U_\gamma - U) & 1 + r
          \end{bmatrix}
     \quad
     \tilde B :=
        \begin{bmatrix}
-       0 \\ 
+       0 \\
        1 + r
        \end{bmatrix}
     \quad \text{and} \quad
     \tilde C :=
        \begin{bmatrix}
-       C \\ 0 
+       C \\ 0
        \end{bmatrix}
-       w_{t+1} 
+       w_{t+1}
 
 
 Please confirm for yourself that, with these definitions, the LQ dynamics :eq:`pilqsd`  match the dynamics of :math:`z_t` and :math:`b_t` described above
@@ -311,12 +301,12 @@ Please confirm for yourself that, with these definitions, the LQ dynamics :eq:`p
 To map utility into the quadratic form :math:`x_t' R x_t + u_t'Q u_t` we can set
 
 * :math:`Q := 1` (remember that we are minimizing) and
-  
-* :math:`R :=` a :math:`4 \times 4` matrix of zeros 
-  
+
+* :math:`R :=` a :math:`4 \times 4` matrix of zeros
+
 However, there is one problem remaining
 
-We have no direct way to capture the non-recursive restriction :eq:`old42` 
+We have no direct way to capture the non-recursive restriction :eq:`old42`
 on the debt sequence :math:`\{b_t\}` from within the LQ framework
 
 To try to enforce it, we're going to use a trick: put a small penalty on :math:`b_t^2` in the criterion function
@@ -328,15 +318,12 @@ That will induce a (hopefully) small approximation error in the decision rule
 We'll check whether it really is small numerically soon
 
 
-
-
-
 Implementation
 ====================
 
 Let's write some code to solve the model
 
-One comment before we start is that the bliss level of consumption :math:`\gamma` in the utility function has no effect on the optimal decision rule 
+One comment before we start is that the bliss level of consumption :math:`\gamma` in the utility function has no effect on the optimal decision rule
 
 We saw this in the previous lecture  :doc:`permanent income <perm_income>`
 
@@ -345,23 +332,20 @@ The reason is that it drops out of the Euler equation for consumption
 In what follows we set it equal to unity
 
 
-
-
 The exogenous noinfinancial income process
 -------------------------------------------
 
-
 First we create the objects for the optimal linear regulator
 
-.. code-block:: julia 
-  :class: test 
+.. code-block:: julia
+  :class: test
 
-  using Test 
+  using Test
 
 .. code-block:: julia
 
     using QuantEcon, LinearAlgebra
-    using PyPlot
+    using PyPlot # Change to Plots
 
     # Set parameters
     α, β, ρ1, ρ2, σ = 10.0, 0.95, 0.9, 0.0, 1.0
@@ -395,10 +379,7 @@ First we create the objects for the optimal linear regulator
     sxbewley = sxo
 
 
-
 The next step is to create the matrices for the LQ system
-
-
 
 .. code-block:: julia
 
@@ -418,10 +399,7 @@ The next step is to create the matrices for the LQ system
     β_LQ = β
 
 
-
 Let's print these out and have a look at them
-
-
 
 .. code-block:: julia
 
@@ -431,11 +409,7 @@ Let's print these out and have a look at them
     println("Q = $QLQ")
 
 
-
-
 Now create the appropriate instance of an LQ model
-
-
 
 .. code-block:: julia
 
@@ -446,14 +420,10 @@ Now create the appropriate instance of an LQ model
 We'll save the implied optimal policy function soon compare them with what we get by
 employing an alternative solution method
 
-
-
 .. code-block:: julia
 
     P, F, d = stationary_values(LQPI)    #  Compute value function and decision rule
     ABF = ALQ - BLQ * F                  #  Form closed loop system
-
-
 
 
 Comparison with the difference equation approach
@@ -462,29 +432,27 @@ Comparison with the difference equation approach
 In our :doc:`first lecture <perm_income>` on the infinite horizon permanent
 income problem we used a different solution method
 
-The method was based around 
+The method was based around
 
 * deducing the Euler equations that are the first-order conditions with respect to consumption and savings
-  
+
 * using the budget constraints and boundary condition to complete a system of expectational linear difference equations
-  
+
 * solving those equations to obtain the solution
 
 Expressed in state space notation, the solution took  the form
 
 .. math::
-    
+
     \begin{aligned}
         z_{t+1} & = A z_t + C w_{t+1} \\
         b_{t+1} & = b_t + U [ (I -\beta A)^{-1} (A - I) ] z_t \\
             y_t & = U z_t \\
-            c_t & = (1-\beta) [ U (I-\beta A)^{-1} z_t - b_t ]    
+            c_t & = (1-\beta) [ U (I-\beta A)^{-1} z_t - b_t ]
     \end{aligned}
 
 
-Now we'll apply the formulas in this system 
-
-
+Now we'll apply the formulas in this system
 
 .. code-block:: julia
 
@@ -509,28 +477,18 @@ Now we'll apply the formulas in this system
     μ_0 = [1.0, 0.0, 0.0, 0.0]
     Σ_0 = zeros(4, 4)
 
-
-
 `A_LSS` calculated as we have here should equal `ABF` calculated above using the LQ model
-
-
 
 .. code-block:: julia
 
     ABF - A_LSS
 
 
-
-
 Now compare pertinent elements of `c_pol` and `F`
-
-
 
 .. code-block:: julia
 
     println(c_pol, -F)
-
-
 
 
 We have verified that the two methods give the same solution
@@ -540,11 +498,10 @@ Now let's create instances of the `LSS <https://github.com/QuantEcon/QuantEcon.j
 To do this, we'll use the outcomes from our second method
 
 
-
 Two Example Economies
 =======================
 
-In the spirit of Bewley models :cite:`Bewley86`, we'll generate panels of consumers 
+In the spirit of Bewley models :cite:`Bewley86`, we'll generate panels of consumers
 
 
 The examples differ only in  the initial states with which we endow the consumers
@@ -552,7 +509,7 @@ The examples differ only in  the initial states with which we endow the consumer
 All other parameter values are kept the same in the two examples
 
 -  In the first example, all consumers begin with zero nonfinancial income and zero debt
-  
+
     * The consumers are thus *ex ante* identical
 
 -  In the second example, while all begin with zero debt, we draw their initial income levels from the invariant distribution of financial income
@@ -560,33 +517,29 @@ All other parameter values are kept the same in the two examples
     * Consumers are *ex ante* heterogeneous
 
 In the first example, consumers' nonfinancial income paths  display
-pronounced transients early in the sample 
+pronounced transients early in the sample
 
-- these will affect outcomes in striking ways 
+- these will affect outcomes in striking ways
 
 Those transient effects will not be present in the second example
 
-We use methods affiliated with the `LSS <https://github.com/QuantEcon/QuantEcon.jl/blob/master/src/lss.jl>`__ type to simulate the model 
+We use methods affiliated with the `LSS <https://github.com/QuantEcon/QuantEcon.jl/blob/master/src/lss.jl>`__ type to simulate the model
 
 
 First set of initial conditions
 --------------------------------
 
-We generate  25 paths of the exogenous non-financial income process and the associated optimal consumption and debt paths. 
-   
+We generate  25 paths of the exogenous non-financial income process and the associated optimal consumption and debt paths.
+
 In a first set of graphs,  darker lines depict a particular sample path, while the lighter lines describe 24 other  paths
 
 A second graph  plots a collection of simulations against the population distribution that we extract from the `LSS` instance LSS
 
 Comparing sample paths with population distributions at each date :math:`t` is a useful exercise---see :ref:`our discussion <lln_mr>` of the laws of large numbers
 
-
-
 .. code-block:: julia
 
     lss = LSS(A_LSS, C_LSS, G_LSS, mu_0=μ_0, Sigma_0=Σ_0)
-
-
 
 
 Population and sample panels
@@ -600,18 +553,9 @@ In the code below, we use the `LSS <https://github.com/QuantEcon/QuantEcon.jl/bl
 -  simulate a group of 25 consumers and plot sample paths on the same
    graph as the population distribution
 
-
-
-
 .. code-block:: julia
 
-    """
-    This function takes initial conditions (μ_0, Σ_0) and uses the LSS
-    type from QuantEcon to  simulate an economy `npaths` times for `T` periods.
-    It then uses that information to generate some graphs related to the discussion
-    below.
-    """
-    function income_consumption_debt_series(A, C, G, μ_0, Σ_0, T=150, npaths=25)
+    function income_consumption_debt_series(A, C, G, μ_0, Σ_0, T = 150, npaths = 25)
 
         lss = LSS(A, C, G, mu_0=μ_0, Sigma_0=Σ_0)
 
@@ -623,7 +567,7 @@ In the code below, we use the `LSS <https://github.com/QuantEcon/QuantEcon.jl/bl
         csim = zeros(Float64, npaths, T)
         ysim = zeros(Float64, npaths, T)
 
-        for i = 1:npaths
+        for i in 1:npaths
             sims = simulate(lss,T)
             bsim[i, :] = sims[1][end, :]
             csim[i, :] = sims[2][2, :]
@@ -631,15 +575,15 @@ In the code below, we use the `LSS <https://github.com/QuantEcon/QuantEcon.jl/bl
         end
 
         # Get the moments
-        cons_mean = zeros(Float64, T)
-        cons_var = zeros(Float64, T)
-        debt_mean = zeros(Float64, T)
-        debt_var = zeros(Float64, T)
-        state = start(moment_generator)
-        for t = 1:T
-            (μ_x, μ_y, Σ_x, Σ_y), state = next(moment_generator, state)
-            cons_mean[t], cons_var[t] = μ_y[2], Σ_y[2, 2]
-            debt_mean[t], debt_var[t] = μ_x[4], Σ_x[4, 4]
+        cons_mean = zeros(T)
+        cons_var = similar(cons_mean)
+        debt_mean = similar(cons_mean)
+        debt_var = similar(cons_mean)
+        for (idx, t) = enumerate(moment_generator)
+            (μ_x, μ_y, Σ_x, Σ_y) = t
+            cons_mean[idx], cons_var[idx] = μ_y[2], Σ_y[2, 2]
+            debt_mean[idx], debt_var[idx] = μ_x[4], Σ_x[4, 4]
+            idx == T && break
         end
         return bsim, csim, ysim, cons_mean, cons_var, debt_mean, debt_var
     end
@@ -659,7 +603,7 @@ In the code below, we use the `LSS <https://github.com/QuantEcon/QuantEcon.jl/bl
         ax[1][:plot](csim', alpha=.1, color="b")
         ax[1][:plot](ysim', alpha=.1, color="g")
         ax[1][:legend](loc=4)
-        ax[1][:set](title="Nonfinancial Income, Consumption, and Debt", 
+        ax[1][:set](title="Nonfinancial Income, Consumption, and Debt",
                     xlabel="t", ylabel="y and c")
 
         # Plot debt
@@ -667,8 +611,8 @@ In the code below, we use the `LSS <https://github.com/QuantEcon/QuantEcon.jl/bl
         ax[2][:plot](bsim', alpha=.1, color="r")
         ax[2][:legend](loc=4)
         ax[2][:set](xlabel="t", ylabel="debt")
-        
-        fig[:tight_layout]        
+
+        fig[:tight_layout]
     end
 
     function consumption_debt_fanchart(csim, cons_mean, cons_var,
@@ -701,7 +645,7 @@ In the code below, we use the `LSS <https://github.com/QuantEcon/QuantEcon.jl/bl
         ax[1][:plot](xvals, csim', color="k", alpha=.25)
         ax[1][:fill_between](xvals, c_perc_95m, c_perc_95p, alpha=.25, color="b")
         ax[1][:fill_between](xvals, c_perc_90m, c_perc_90p, alpha=.25, color="r")
-        ax[1][:set](title="Consumption/Debt over time", 
+        ax[1][:set](title="Consumption/Debt over time",
                     ylim=(cmean-15, cmean+15), ylabel="consumption")
 
         # Debt fan
@@ -710,17 +654,11 @@ In the code below, we use the `LSS <https://github.com/QuantEcon/QuantEcon.jl/bl
         ax[2][:fill_between](xvals, d_perc_95m, d_perc_95p, alpha=.25, color="b")
         ax[2][:fill_between](xvals, d_perc_90m, d_perc_90p, alpha=.25, color="r")
         ax[2][:set](ylabel="debt", xlabel="t")
-        
-        fig[:tight_layout]        
+
+        fig[:tight_layout]
     end
 
-
-
-
 Now let's create figures with initial conditions of zero for :math:`y_0` and :math:`b_0`
-
-
-
 
 .. code-block:: julia
 
@@ -729,22 +667,15 @@ Now let's create figures with initial conditions of zero for :math:`y_0` and :ma
     cons_mean0, cons_var0, debt_mean0, debt_var0 = out[4:end]
 
     consumption_income_debt_figure(bsim0, csim0, ysim0)
-    
-
-    
-
 
 .. code-block:: julia
 
     consumption_debt_fanchart(csim0, cons_mean0, cons_var0,
                               bsim0, debt_mean0, debt_var0)
 
-
-
-
 Here is what is going on in the above graphs
 
-For our simulation, we have set initial conditions :math:`b_0 = y_{-1} = y_{-2} = 0` 
+For our simulation, we have set initial conditions :math:`b_0 = y_{-1} = y_{-2} = 0`
 
 Because :math:`y_{-1} = y_{-2} = 0`, nonfinancial income :math:`y_t` starts far below its stationary mean :math:`\mu_{y, \infty}` and rises early in each simulation
 
@@ -754,14 +685,13 @@ Recall from  the :doc:`previous lecture <perm_income>` that we can represent the
 .. math::
     :label: old12
 
-    (1-\beta) b_t + c_t = (1-\beta) E_t \sum_{j=0}^\infty \beta^j y_{t+j} 
-
+    (1-\beta) b_t + c_t = (1-\beta) E_t \sum_{j=0}^\infty \beta^j y_{t+j}
 
 So at time :math:`0` we have
 
 .. math::
 
-    c_0 = (1-\beta) E_0 \sum_{t=0}^\infty \beta^j y_{t}  
+    c_0 = (1-\beta) E_0 \sum_{t=0}^\infty \beta^j y_{t}
 
 
 This tells us that consumption starts at the income that would be paid by an annuity whose value equals the expected discounted value of nonfinancial income at time :math:`t=0`
@@ -774,7 +704,7 @@ He uses the gap between consumption and nonfinancial income mostly to service th
 
 Thus, when we look at the panel of debt in the accompanying graph, we see that this is a group of *ex ante* identical people each of whom starts with zero debt
 
-All of them accumulate debt in anticipation of rising nonfinancial income 
+All of them accumulate debt in anticipation of rising nonfinancial income
 
 They expect their nonfinancial income to rise toward the invariant distribution of income, a consequence of our having started them at :math:`y_{-1} = y_{-2} = 0`
 
@@ -782,12 +712,10 @@ They expect their nonfinancial income to rise toward the invariant distribution 
 Cointegration residual
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-
-
 The following figure plots realizations of the left side of :eq:`old12`, which,
 :ref:`as discussed in our last lecture <coint_pi>`, is called the **cointegrating residual**
 
-As mentioned above, the right side can be thought of as an 
+As mentioned above, the right side can be thought of as an
 annuity payment on the expected present value of future income
 :math:`E_t \sum_{j=0}^\infty \beta^j y_{t+j}`
 
@@ -808,13 +736,8 @@ behavior early in the sample.
 By altering initial conditions, we shall remove this transient in our second example to be presented below
 
 
-
-
 .. code-block:: julia
 
-    """
-    Plots the cointegration
-    """
     function cointegration_figure(bsim, csim)
         # Create figure
         fig, ax = subplots(figsize=(10, 8))
@@ -824,11 +747,6 @@ By altering initial conditions, we shall remove this transient in our second exa
     end
 
     cointegration_figure(bsim0, csim0)
-
-
-
-
-
 
 
 A "borrowers and lenders" closed economy
@@ -845,7 +763,7 @@ anticipation of rising incomes
 
 So with the economic primitives set as above, the economy converges to a
 steady state in which there is an excess aggregate supply of risk-free
-loans at a gross interest rate of :math:`R` 
+loans at a gross interest rate of :math:`R`
 
 This excess supply is filled by "foreigner lenders" willing to make those loans
 
@@ -864,14 +782,13 @@ with each other at a gross risk-free interest rate of
 Across the group of people being analyzed, risk-free loans are in zero excess supply
 
 
-We have arranged primitives so that :math:`R = \beta^{-1}` clears the market for risk-free loans at zero aggregate excess supply 
+We have arranged primitives so that :math:`R = \beta^{-1}` clears the market for risk-free loans at zero aggregate excess supply
 
 So the risk-free loans are being made from one person to another within our closed set of agent
 
 There is no need for foreigners to lend to our group
 
 Let's have a look at the corresponding figures
-
 
 
 .. code-block:: julia
@@ -881,10 +798,6 @@ Let's have a look at the corresponding figures
     cons_meanb, cons_varb, debt_meanb, debt_varb = out[4:end]
 
     consumption_income_debt_figure(bsimb, csimb, ysimb)
-    
-
-    
-
 
 
 .. code-block:: julia
@@ -893,11 +806,10 @@ Let's have a look at the corresponding figures
                               bsimb, debt_meanb, debt_varb)
 
 
-
 The graphs confirm the following outcomes:
 
 -  As before, the consumption distribution spreads out over time
-  
+
 But now there is some initial dispersion because there is *ex ante* heterogeneity in the initial draws of :math:`\begin{bmatrix} y_{-1} \\ y_{-2}   \end{bmatrix}`
 
 -  As before, the cross-section distribution of debt spreads out over time
@@ -910,8 +822,6 @@ But now there is some initial dispersion because there is *ex ante* heterogeneit
 Let's have a look at the cointegration figure
 
 
-
 .. code-block:: julia
 
     cointegration_figure(bsimb, csimb)
-

--- a/rst_files/perm_income_cons.rst
+++ b/rst_files/perm_income_cons.rst
@@ -439,7 +439,7 @@ Now create the appropriate instance of an LQ model
 
 .. code-block:: julia
 
-    LQPI = LQ(QLQ, RLQ, ALQ, BLQ, CLQ, bet=β_LQ)
+    LQPI = QuantEcon.LQ(QLQ, RLQ, ALQ, BLQ, CLQ, bet=β_LQ);
 
 
 

--- a/rst_files/perm_income_cons.rst
+++ b/rst_files/perm_income_cons.rst
@@ -353,11 +353,14 @@ The exogenous noinfinancial income process
 
 First we create the objects for the optimal linear regulator
 
+.. code-block:: julia 
+  :class: test 
 
+  using Test 
 
 .. code-block:: julia
 
-    using QuantEcon
+    using QuantEcon, LinearAlgebra
     using PyPlot
 
     # Set parameters
@@ -486,8 +489,8 @@ Now we'll apply the formulas in this system
 .. code-block:: julia
 
     # Use the above formulas to create the optimal policies for b_{t+1} and c_t
-    b_pol = G * (inv(eye(3, 3) - β * A)) * (A - eye(3, 3))
-    c_pol = (1 - β) * (G * inv(eye(3, 3) - β * A))
+    b_pol = G * (inv(I - β * A)) * (A - I)
+    c_pol = (1 - β) * (G * inv(I - β * A))
 
     # Create the A matrix for a LinearStateSpace instance
     A_LSS1 = vcat(A, b_pol)
@@ -616,9 +619,9 @@ In the code below, we use the `LSS <https://github.com/QuantEcon/QuantEcon.jl/bl
         moment_generator = moment_sequence(lss)
 
         # Simulate various paths
-        bsim = Array{Float64}(npaths, T)
-        csim = Array{Float64}(npaths, T)
-        ysim = Array{Float64}(npaths, T)
+        bsim = zeros(Float64, npaths, T)
+        csim = zeros(Float64, npaths, T)
+        ysim = zeros(Float64, npaths, T)
 
         for i = 1:npaths
             sims = simulate(lss,T)
@@ -628,10 +631,10 @@ In the code below, we use the `LSS <https://github.com/QuantEcon/QuantEcon.jl/bl
         end
 
         # Get the moments
-        cons_mean = Array{Float64}(T)
-        cons_var = Array{Float64}(T)
-        debt_mean = Array{Float64}(T)
-        debt_var = Array{Float64}(T)
+        cons_mean = zeros(Float64, T)
+        cons_var = zeros(Float64, T)
+        debt_mean = zeros(Float64, T)
+        debt_var = zeros(Float64, T)
         state = start(moment_generator)
         for t = 1:T
             (μ_x, μ_y, Σ_x, Σ_y), state = next(moment_generator, state)

--- a/rst_files/perm_income_cons.rst
+++ b/rst_files/perm_income_cons.rst
@@ -600,15 +600,15 @@ In the code below, we use the `LSS <https://github.com/QuantEcon/QuantEcon.jl/bl
         # Plot consumption and income
         ax[1][:plot](csim[1, :], label="c", color="b")
         ax[1][:plot](ysim[1, :], label="y", color="g")
-        ax[1][:plot](csim', alpha=.1, color="b")
-        ax[1][:plot](ysim', alpha=.1, color="g")
+        ax[1][:plot](Array(csim'), alpha=.1, color="b")
+        ax[1][:plot](Array(ysim'), alpha=.1, color="g")
         ax[1][:legend](loc=4)
         ax[1][:set](title="Nonfinancial Income, Consumption, and Debt",
                     xlabel="t", ylabel="y and c")
 
         # Plot debt
         ax[2][:plot](bsim[1, :], label="b", color="r")
-        ax[2][:plot](bsim', alpha=.1, color="r")
+        ax[2][:plot](Array(bsim'), alpha=.1, color="r")
         ax[2][:legend](loc=4)
         ax[2][:set](xlabel="t", ylabel="debt")
 
@@ -642,7 +642,7 @@ In the code below, we use the `LSS <https://github.com/QuantEcon/QuantEcon.jl/bl
 
         # Consumption fan
         ax[1][:plot](xvals, cons_mean, color="k")
-        ax[1][:plot](xvals, csim', color="k", alpha=.25)
+        ax[1][:plot](xvals, Array(csim'), color="k", alpha=.25)
         ax[1][:fill_between](xvals, c_perc_95m, c_perc_95p, alpha=.25, color="b")
         ax[1][:fill_between](xvals, c_perc_90m, c_perc_90p, alpha=.25, color="r")
         ax[1][:set](title="Consumption/Debt over time",
@@ -650,7 +650,7 @@ In the code below, we use the `LSS <https://github.com/QuantEcon/QuantEcon.jl/bl
 
         # Debt fan
         ax[2][:plot](xvals, debt_mean, color="k")
-        ax[2][:plot](xvals, bsim', color="k", alpha=.25)
+        ax[2][:plot](xvals, Array(bsim'), color="k", alpha=.25)
         ax[2][:fill_between](xvals, d_perc_95m, d_perc_95p, alpha=.25, color="b")
         ax[2][:fill_between](xvals, d_perc_90m, d_perc_90p, alpha=.25, color="r")
         ax[2][:set](ylabel="debt", xlabel="t")


### PR DESCRIPTION
~WIP.~

Also: There's a function the v0.6 function relies on (`start(moment_generator)`, where `moment_generator = moment_sequence(lss)`) which isn't in the latest tagged release of QuantEcon (`v0.18.1`). @Nosferican, how should I proceed?