### PR TITLE
Structs => NamedTuples: "A Problem that Stumped Milton Friedman"

### DIFF
--- a/rst_files/wald_friedman.rst
+++ b/rst_files/wald_friedman.rst
@@ -540,26 +540,6 @@ We shall construct two types that
 
     =#
 
-    mutable struct WFSolution{TAV <: AbstractVector, TR<:Real}
-        J::TAV
-        lb::TR
-        ub::TR
-    end
-
-    struct WaldFriedman{TR <: Real,
-                        TI <: Integer,
-                        TAV1 <: AbstractVector,
-                        TAV2 <: AbstractVector}
-        c::TR
-        L0::TR
-        L1::TR
-        f0::TAV1
-        f1::TAV1
-        m::TI
-        pgrid::TAV2
-        sol::WFSolution
-    end
-
     function WaldFriedman(c, L0, L1, f0, f1; m = 25)
 
         pgrid = range(0.0, stop = 1.0, length = m)
@@ -573,7 +553,8 @@ We shall construct two types that
         lb = 0.
         ub = 0.
 
-        WaldFriedman(c, L0, L1, f0, f1, m, pgrid, WFSolution(J, lb, ub))
+        WFSolution = (J = J, lb = lb, ub = ub)
+        (c = c, L0 = L0, L1 = L1, f0 = f0, f1 = f1, m = m, pgrid = pgrid, WFSolution = WFSolution)
     end
 
     current_distribution(wf::WaldFriedman, p::Real) = p * wf.f0 + (1 - p) * wf.f1

--- a/rst_files/wald_friedman.rst
+++ b/rst_files/wald_friedman.rst
@@ -554,10 +554,10 @@ We shall construct two types that
         ub = 0.
 
         WFSolution = (J = J, lb = lb, ub = ub)
-        (c = c, L0 = L0, L1 = L1, f0 = f0, f1 = f1, m = m, pgrid = pgrid, WFSolution = WFSolution)
+        (c = c, L0 = L0, L1 = L1, f0 = f0, f1 = f1, m = m, pgrid = pgrid, sol = WFSolution)
     end
 
-    current_distribution(wf::WaldFriedman, p::Real) = p * wf.f0 + (1 - p) * wf.f1
+    current_distribution(wf, p) = p * wf.f0 + (1 - p) * wf.f1
 
     function bayes_update_k(wf, p, k)
         f0_k = wf.f0[k]
@@ -625,23 +625,24 @@ We shall construct two types that
         return lb, ub
     end
 
-    function solve_model!(wf; tol = 1e-7)
+    function solve_model(wf; tol = 1e-7)
         bell_op(x) = bellman_operator(wf, x)
-        J =  compute_fixed_point(bell_op, zeros(wf.m), err_tol=tol, print_skip=5)
-
-        wf.sol.J = J
-        wf.sol.lb, wf.sol.ub = find_cutoff_rule(wf, J)
-        return J
+        J = compute_fixed_point(bell_op, zeros(wf.m), err_tol=tol, print_skip=5)
+        lb, ub = find_cutoff_rule(wf, J)
+        WFSolution = (J = J, lb = lb, ub = ub)
+        wf_new = (c = wf.c, L0 = wf.L0, L1 = wf.L1, f0 = wf.f0, f1 = wf.f1, m = wf.m, pgrid = wf.pgrid, sol = WFSolution)
     end
 
     function simulate(wf, f; p0 = 0.5)
         # Check whether vf is computed
         if sum(abs, wf.sol.J) < 1e-8
-            solve_model!(wf)
+            wf! = solve_model(wf)
+        else 
+            wf! = wf 
         end
 
         # Unpack useful info
-        lb, ub = wf.sol.lb, wf.sol.ub
+        lb, ub = wf!.sol.lb, wf!.sol.ub
         drv = DiscreteRV(f)
 
         # Initialize a couple useful variables
@@ -671,7 +672,7 @@ We shall construct two types that
     struct F0 <: HiddenDistribution end
     struct F1 <: HiddenDistribution end
 
-    function simulate_tdgp(wf, f; p0 = 0.5)
+    function simulate_tdgp(wf, f::F0; p0 = 0.5)
         decision, p, t = simulate(wf, wf.f0; p0=p0)
 
         correct = (decision == 0)
@@ -679,7 +680,7 @@ We shall construct two types that
         return correct, p, t
     end
 
-    function simulate_tdgp(wf, f; p0 = 0.5)
+    function simulate_tdgp(wf, f::F1; p0 = 0.5)
         decision, p, t = simulate(wf, wf.f1; p0=p0)
 
         correct = (decision == 1)

--- a/rst_files/wald_friedman.rst
+++ b/rst_files/wald_friedman.rst
@@ -655,7 +655,7 @@ We shall construct two types that
             # the draws come from the "right" distribution
             k = rand(drv)
             t = t + 1
-            p = bayes_update_k(wf, p, k)
+            p = bayes_update_k(wf!, p, k)
             if p < lb
                 decision = 1
                 break
@@ -759,7 +759,7 @@ We'll start with the following parameterization
       wf = WaldFriedman(c, L0, L1, f0, f1; m = m);
 
       # Solve and simulate the solution
-      cdist, tdist = stopping_dist(wf; ndraws = 5000)
+      cdist, tdist = stopping_dist(wf; ndraws = 500)
 
       a = plot([f0 f1],
           xlabel = L"$k$ Values",


### PR DESCRIPTION
~~(WIP: See #152)~~ Opening this PR as an example for @XiaojunGuan. In particular: 

1. Note that we can still use the constructors, even though we've ripped out the types. That way, we don't need to rewrite the intermediate value calculations. 

2. We need to get rid of type annotations on methods, like `current_distribution(wf, p)` (modulo dispatch, as we discussed). The actual method bodies generally don't need to change, since we can use dot notation (`x.y`) to get values from named tuples. 

3. Corollary to (2) is keeping field names consistent. Sometimes this involves nesting named tuples, like we do with the field `sol` of the return of `function WaldFriedman(c, L0, L1, f0, f1; m = 25)`.

4. Sometimes we'll have dummy types, like `struct F0 <: HiddenDistribution end`, that we use for dispatch. I think we can leave these in for now, but we'll rip them out eventually since they abuse the dispatch system (@jlperla?). 

5. We need to change any logic that relies on mutating the state of a `struct`, since that's not possible anymore. See what we did to the function `solve_model!` and `simulate`. 

6. Lastly, we want to make sure tests pass. One way to do this is to run the notebook from the command line (`./run-notebook.sh wald_friedman.ipynb`) and then inspecting the result in `notebooks/`. Or, you could open the notebook in `_build/jupyter` and run all cells. 

Also- if you look at the Julia code vs Python on this and at the plot titles/lecture text, it looks like somewhere along the line the 500 iterations got changed to 5000. This is probably why the lecture takes roughly 10X longer to run on Julia per the build server. So I set it back. 