### PR TITLE
[CONF] add s3 urlprefix 

### DIFF
--- a/rst_files/conf.py
+++ b/rst_files/conf.py
@@ -421,3 +421,6 @@ jupyter_target_html = True
 
 #Drop Tests Embedded in Lectures
 jupyter_drop_tests = False
+
+#Use urlprefix images
+jupyter_images_urlpath = "https://s3-ap-southeast-2.amazonaws.com/compare-lectures.quantecon.org/jl/_static/"


### PR DESCRIPTION
This PR adjusts `conf.py` to add a url reference for static assets in generated notebooks. 

Current location is `s3` compare-lectures bucket. 

This will need to be updated in the future. 

This will require the latest `sphinxcontrib-jupyter` version. 