### PR TITLE
remove spaces around tag in deps.jl

### DIFF
--- a/rst_files/_static/includes/deps.jl
+++ b/rst_files/_static/includes/deps.jl
@@ -1,6 +1,6 @@
 using InstantiateFromURL
 
 # activate the QuantEcon environment
-activate_github("QuantEcon/QuantEconLecturePackages", tag = "v0.9.0") 
+activate_github("QuantEcon/QuantEconLecturePackages", tag="v0.9.0") 
 
 using LinearAlgebra, Statistics, Compat # load common packages


### PR DESCRIPTION
Is this standard? I'm used to seeing no spaces around keyword arguments