### PR TITLE
fix displayname for Jupyter kernel used in construction of website

### DIFF
--- a/rst_files/conf.py
+++ b/rst_files/conf.py
@@ -393,7 +393,7 @@ jupyter_kernels = {
     },
     "julia": {
         "kernelspec": {
-            "display_name": "Julia 1.0",
+            "display_name": "Julia",
             "language": "julia",
             "name": "julia-1.0"
             },


### PR DESCRIPTION
this needs to be the basename `Julia` for the website to properly construct the `breadcrumbs` navigation tool. It will still latch onto `Julia-1.0` kernel.