### PR TITLE
Correct typo in classification of the README file

### DIFF
--- a/rst_files/version_control.rst
+++ b/rst_files/version_control.rst
@@ -535,7 +535,7 @@ Follow the instructions to create a `new repository <new_repo_workflow>`_ for on
 In this repository
 
 * Take the code from one of your previous assignments, such as `Newton's method <jbe_ex8a>`_ in `Introductory Examples <julia_by_example>`_ (either as a ``.jl`` file or a Jupyter notebook)
-* Put in a ``README.jl`` with some text
+* Put in a ``README.md`` with some text
 * Put in a ``.gitignore`` file, ignoring the Jupyter files ``.ipynb_checkpoints`` and the project files, ``.projects``
 
 Exercise 1b


### PR DESCRIPTION
From README.jl to README.md