### PR TITLE
update default to drop tests and add jupyter-tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ help:
 jupyter:
 	@$(SPHINXBUILD) -M jupyter "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) 
 
-jupyter-notest:
-	@$(SPHINXBUILD) -M jupyter "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) -D jupyter_drop_tests=1
+jupyter-tests:
+	@$(SPHINXBUILD) -M jupyter "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) -D jupyter_drop_tests=0
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).

--- a/rst_files/conf.py
+++ b/rst_files/conf.py
@@ -420,7 +420,7 @@ jupyter_allow_html_only = True
 jupyter_target_html = True
 
 #Drop Tests Embedded in Lectures
-jupyter_drop_tests = False
+jupyter_drop_tests = True
 
 #Use urlprefix images
 jupyter_images_urlpath = "https://s3-ap-southeast-2.amazonaws.com/compare-lectures.quantecon.org/jl/_static/"


### PR DESCRIPTION
To generate lecture set with tests you will now need to use `jupyter-tests`. 