### PR TITLE
kalman plots

### DIFF
--- a/rst_files/kalman.rst
+++ b/rst_files/kalman.rst
@@ -129,9 +129,11 @@ This density :math:`p(x)` is shown below as a contour map, with the center of th
     two_args_to_pdf(dist) = (x, y) -> pdf(dist, [x, y]) # returns a function to be plotted
 
     # plot
-    contour(x_grid, y_grid, two_args_to_pdf(dist), fill = true, levels = 6, 
-            color = :lightrainbow, alpha = 0.6, cbar = false) 
-            # saves us the trouble of reshaping a data matrix to be a Cartesian grid
+    contour(x_grid, y_grid, two_args_to_pdf(dist), fill = true,
+        color = :lighttest, cbar = false)
+    contour!(x_grid, y_grid, two_args_to_pdf(dist), fill = false, levels = 6, lw=1,
+        color = :grays, cbar = false)
+        # saves us the trouble of reshaping a data matrix to be a Cartesian grid
 
 .. code-block:: julia
     :class: test
@@ -221,14 +223,18 @@ The original density is left in as contour lines for comparison
 
     # plot the new density on the old plot
     newdist = MvNormal(x_hat_F, Symmetric(Σ_F)) # because Σ_F
-    contour!(x_grid, y_grid, two_args_to_pdf(newdist), fill = false, levels = 6, 
-             color = :grays, cbar = false)
+    contour(x_grid, y_grid, two_args_to_pdf(newdist), fill = true,
+         color = :lighttest, cbar = false)
+    contour!(x_grid, y_grid, two_args_to_pdf(newdist), fill = false, levels = 7,
+         color = :grays, cbar = false)
+    contour!(x_grid, y_grid, two_args_to_pdf(dist), fill = false, levels = 14, lw=1,
+         color = :grays, cbar = false)
 
 .. code-block:: julia
     :class: test
 
     @testset "Updated Belief Tests" begin
-        @test M ≈ [0.6666666666666667 1.1102230246251565e-16; 
+        @test M ≈ [0.6666666666666667 1.1102230246251565e-16;
                    1.1102230246251565e-16 0.6666666666666667]
         @test Σ_F ≈ [0.13333333333333325 0.09999999999999992;
                      0.09999999999999998 0.15000000000000002]
@@ -330,8 +336,12 @@ the update has used parameters
     predictdist = MvNormal(new_x_hat, Symmetric(new_Σ))
 
     # Plot Density 3
-    contour!(x_grid, y_grid, two_args_to_pdf(predictdist), fill = false, levels = 6, 
-             color = :grays, cbar = false)
+    contour(x_grid, y_grid, two_args_to_pdf(predictdist), fill = true,
+         color = :lighttest, cbar = false)
+    contour!(x_grid, y_grid, two_args_to_pdf(predictdist), fill = false, levels = 6,
+         color = :grays, cbar = false)
+    contour!(x_grid, y_grid, two_args_to_pdf(dist), fill = false, levels = 6,
+         color = :grays, cbar = false)
 
 .. code-block:: julia
     :class: test
@@ -717,9 +727,9 @@ Exercise 3
         e2[t] = sum((a - b)^2 for (a, b) in zip(x, Ax))
     end
 
-    plot(1:T, e1, color = :black, linewidth = 2, alpha = 0.6, label = "Kalman filter error", 
+    plot(1:T, e1, color = :black, linewidth = 2, alpha = 0.6, label = "Kalman filter error",
          grid = false)
-    plot!(1:T, e2, color = :green, linewidth = 2, alpha = 0.6, 
+    plot!(1:T, e2, color = :green, linewidth = 2, alpha = 0.6,
           label = "conditional expectation error")
 
 .. code-block:: julia

--- a/rst_files/kalman.rst
+++ b/rst_files/kalman.rst
@@ -129,11 +129,10 @@ This density :math:`p(x)` is shown below as a contour map, with the center of th
     two_args_to_pdf(dist) = (x, y) -> pdf(dist, [x, y]) # returns a function to be plotted
 
     # plot
-    contour(x_grid, y_grid, two_args_to_pdf(dist), fill = true,
-        color = :lighttest, cbar = false)
-    contour!(x_grid, y_grid, two_args_to_pdf(dist), fill = false, levels = 6, lw=1,
-        color = :grays, cbar = false)
-        # saves us the trouble of reshaping a data matrix to be a Cartesian grid
+    contour(x_grid, y_grid, two_args_to_pdf(dist), fill = false, 
+            color = :lighttest, cbar = false)
+    contour!(x_grid, y_grid, two_args_to_pdf(dist), fill = false, lw=1,
+             color = :grays, cbar = false)
 
 .. code-block:: julia
     :class: test
@@ -223,12 +222,12 @@ The original density is left in as contour lines for comparison
 
     # plot the new density on the old plot
     newdist = MvNormal(x_hat_F, Symmetric(Σ_F)) # because Σ_F
-    contour(x_grid, y_grid, two_args_to_pdf(newdist), fill = true,
-         color = :lighttest, cbar = false)
+    contour!(x_grid, y_grid, two_args_to_pdf(newdist), fill = false,
+             color = :lighttest, cbar = false)
     contour!(x_grid, y_grid, two_args_to_pdf(newdist), fill = false, levels = 7,
-         color = :grays, cbar = false)
-    contour!(x_grid, y_grid, two_args_to_pdf(dist), fill = false, levels = 14, lw=1,
-         color = :grays, cbar = false)
+             color = :grays, cbar = false)
+    contour!(x_grid, y_grid, two_args_to_pdf(dist), fill = false, levels = 7, lw=1,
+             color = :grays, cbar = false)
 
 .. code-block:: julia
     :class: test
@@ -336,12 +335,13 @@ the update has used parameters
     predictdist = MvNormal(new_x_hat, Symmetric(new_Σ))
 
     # Plot Density 3
-    contour(x_grid, y_grid, two_args_to_pdf(predictdist), fill = true,
-         color = :lighttest, cbar = false)
-    contour!(x_grid, y_grid, two_args_to_pdf(predictdist), fill = false, levels = 6,
-         color = :grays, cbar = false)
-    contour!(x_grid, y_grid, two_args_to_pdf(dist), fill = false, levels = 6,
-         color = :grays, cbar = false)
+    contour(x_grid, y_grid, two_args_to_pdf(predictdist), fill = false, lw = 1, color = :lighttest, 
+            cbar = false)
+    contour!(x_grid, y_grid, two_args_to_pdf(dist),
+             color = :grays, cbar = false)
+    contour!(x_grid, y_grid, two_args_to_pdf(newdist), fill = false, levels = 7,
+             color = :grays, cbar = false)
+    annotate!(y[1], y[2], "y", color = :black)
 
 .. code-block:: julia
     :class: test


### PR DESCRIPTION
The plots have been modified to match the original plots more closely.

Namely: adding back the grey contour lines and changing the colour scheme.

One thing I noticed (that may be an issue) is that the newdist grid messes with the dist grid and the predicteddist grid. Notably, in the third plot I had to bump up the number of contour lines for the dist grid to 14 as opposed to 6, as having 6 contours meant that only 2 or 3 of them were in the dimensions of the figure. For the last figure I omitted the newdist grid since it caused the predictdist surface to lose some of its granularity, going from several colours to only 2 or 3. 