### PR TITLE
Make Names Reflect Math [WIP]

### DIFF
--- a/rst_files/kalman.rst
+++ b/rst_files/kalman.rst
@@ -37,7 +37,7 @@ Setup
 
 .. code-block:: julia
 
-    using LinearAlgebra, Statistics, Compat 
+    using LinearAlgebra, Statistics, Compat
 
 The Basic Idea
 ====================
@@ -111,7 +111,7 @@ This density :math:`p(x)` is shown below as a contour map, with the center of th
     # set up prior objects
     Σ = [0.4  0.3
          0.3  0.45]
-    x_hat = [0.2, -0.2]
+    x̂ = [0.2, -0.2]
 
     # define G and R from the equation y = Gx + N(0, R)
     G = I # this is a generic identity object that conforms to the right dimensions
@@ -129,7 +129,7 @@ This density :math:`p(x)` is shown below as a contour map, with the center of th
     y_grid = range(-3.1, 1.7, length = 100)
 
     # generate distribution
-    dist = MvNormal(x_hat, Σ)
+    dist = MvNormal(x̂, Σ)
     two_args_to_pdf(dist) = (x, y) -> pdf(dist, [x, y]) # returns a function to be plotted
 
     # plot
@@ -221,11 +221,11 @@ The original density is left in as contour lines for comparison
 
     # define posterior objects
     M = Σ * G' * inv(G * Σ * G' + R)
-    x_hat_F = x_hat + M * (y - G * x_hat)
+    x̂_F = x̂ + M * (y - G * x̂)
     Σ_F = Σ - M * G * Σ
 
     # plot the new density on the old plot
-    newdist = MvNormal(x_hat_F, Symmetric(Σ_F)) # because Σ_F
+    newdist = MvNormal(x̂_F, Symmetric(Σ_F)) # because Σ_F
     contour!(x_grid, y_grid, two_args_to_pdf(newdist), fill = false,
              color = :lighttest, cbar = false)
     contour!(x_grid, y_grid, two_args_to_pdf(newdist), fill = false, levels = 7,
@@ -334,9 +334,9 @@ the update has used parameters
 .. code-block:: julia
 
     # get the predictive distribution
-    new_x_hat = A * x_hat_F
+    new_x̂ = A * x̂_F
     new_Σ = A * Σ_F * A' + Q
-    predictdist = MvNormal(new_x_hat, Symmetric(new_Σ))
+    predictdist = MvNormal(new_x̂, Symmetric(new_Σ))
 
     # Plot Density 3
     contour(x_grid, y_grid, two_args_to_pdf(predictdist), fill = false, lw = 1, color = :lighttest,
@@ -351,7 +351,7 @@ the update has used parameters
     :class: test
 
     @testset "Prediction Test" begin
-        @test new_x_hat ≈ [1.9199999999999995, 0.26666666666666655]
+        @test new_x̂ ≈ [1.9199999999999995, 0.26666666666666655]
         @test new_Σ ≈ [0.312 0.066; 0.066 0.141]
     end
 
@@ -608,17 +608,17 @@ Exercise 1
     # parameters
     θ = 10
     A, G, Q, R = 1.0, 1.0, 0.0, 1.0
-    x_hat_0, Σ_0 = 8.0, 1.0
+    x̂_0, Σ_0 = 8.0, 1.0
 
     # initialize Kalman filter
     kalman = Kalman(A, G, Q, R)
-    set_state!(kalman, x_hat_0, Σ_0)
+    set_state!(kalman, x̂_0, Σ_0)
 
     xgrid = range(θ - 5, θ + 2, length = 200)
     densities = zeros(200, 5) # one column per round of updating
     for i in 1:5
         # record the current predicted mean and variance, and plot their densities
-        m, v = kalman.cur_x_hat, kalman.cur_sigma
+        m, v = kalman.cur_x̂, kalman.cur_sigma
         densities[:, i] = pdf.(Normal(m, sqrt(v)), xgrid)
 
         # generate the noisy signal
@@ -649,7 +649,7 @@ Exercise 2
     Random.seed!(42)  # reproducible results
     ϵ = 0.1
     kalman = Kalman(A, G, Q, R)
-    set_state!(kalman, x_hat_0, Σ_0)
+    set_state!(kalman, x̂_0, Σ_0)
 
     nodes, weights = qnwlege(21, θ-ϵ, θ+ϵ)
 
@@ -657,7 +657,7 @@ Exercise 2
     z = zeros(T)
     for t in 1:T
         # Record the current predicted mean and variance, and plot their densities
-        m, v = kalman.cur_x_hat, kalman.cur_sigma
+        m, v = kalman.cur_x̂, kalman.cur_sigma
         dist = Normal(m, sqrt(v))
         E = expectation(dist, nodes)
         integral = E(x -> 1) # Just take the pdf integral
@@ -697,11 +697,11 @@ Exercise 3
     # define the prior density
     Σ = [0.9 0.3
             0.3 0.9]
-    x_hat = [8, 8]
+    x̂ = [8, 8]
 
     # initialize the Kalman filter
     kn = Kalman(A, G, Q, R)
-    set_state!(kn, x_hat, Σ)
+    set_state!(kn, x̂, Σ)
 
     # set the true initial value of the state
     x = zeros(2)
@@ -727,7 +727,7 @@ Exercise 3
         # update state and record error
         Ax = A * x
         x = rand(MultivariateNormal(Ax, Q))
-        e1[t] = sum((a - b)^2 for (a, b) in zip(x, kn.cur_x_hat))
+        e1[t] = sum((a - b)^2 for (a, b) in zip(x, kn.cur_x̂))
         e2[t] = sum((a - b)^2 for (a, b) in zip(x, Ax))
     end
 

--- a/rst_files/lake_model.rst
+++ b/rst_files/lake_model.rst
@@ -958,16 +958,16 @@ Here are the other parameters:
 
 .. code-block:: julia
 
-    b_hat = 0.003
-    T_hat = 20
+    b̂ = 0.003
+    T̂ = 20
 
 Let's increase :math:`b` to the new value and simulate for 20 periods
 
 .. code-block:: julia
 
-    lm = LakeModel(b=b_hat)
-    X_path1 = simulate_stock_path(lm, x0 * N0, T_hat)   # simulate stocks
-    x_path1 = simulate_rate_path(lm, x0, T_hat)         # simulate rates
+    lm = LakeModel(b=b̂)
+    X_path1 = simulate_stock_path(lm, x0 * N0, T̂)   # simulate stocks
+    x_path1 = simulate_rate_path(lm, x0, T̂)         # simulate rates
 
 Now we reset :math:`b` to the original value and then, using the state
 after 20 periods for the new initial conditions, we simulate for the
@@ -976,8 +976,8 @@ additional 30 periods
 .. code-block:: julia
 
     lm = LakeModel(b = 0.0124)
-    X_path2 = simulate_stock_path(lm, X_path1[:, end-1], T-T_hat+1)    # simulate stocks
-    x_path2 = simulate_rate_path(lm, x_path1[:, end-1], T-T_hat+1)     # simulate rates
+    X_path2 = simulate_stock_path(lm, X_path1[:, end-1], T-T̂+1)    # simulate stocks
+    x_path2 = simulate_rate_path(lm, x_path1[:, end-1], T-T̂+1)     # simulate rates
 
 Finally we combine these two paths and plot
 


### PR DESCRIPTION
cc @PooyaFa, this is to resolve https://github.com/QuantEcon/lecture-source-jl/issues/236. You can add commits to this branch in your subsequent work.

Things to check: 

- [ ] No messy names like `bellman_operator`, etc. when we can avoid them. 
- [ ] No `_tilde` or `_hat` etc. when the base symbol is a *Latin letter* (for Greek letters, like `\omega_hat`, we can't use the glyphs). 
