### PR TITLE
Add Parallel Execution Option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ SPHINXBUILD   = python -msphinx
 SPHINXPROJ    = lecture-source-jl
 SOURCEDIR     = source/rst
 BUILDDIR      = _build
+CORES 		  = 4
 
 # Put it first so that "make" without argument is like "make help".
 setup:
@@ -25,6 +26,9 @@ jupyter-tests:
 
 preview:
 	cd _build/jupyter_html/ && python -m http.server
+
+jupyter_parallel:
+	@$(SPHINXBUILD) -M jupyter "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) -D jupyter_number_workers=$(CORES)
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ jupyter-tests:
 preview:
 	cd _build/jupyter_html/ && python -m http.server
 
-jupyter_parallel:
+jupyter-parallel:
 	@$(SPHINXBUILD) -M jupyter "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) -D jupyter_number_workers=$(CORES)
 
 # Catch-all target: route all unknown targets to Sphinx using the new

--- a/source/rst/conf.py
+++ b/source/rst/conf.py
@@ -449,6 +449,3 @@ jupyter_html_template = "theme/templates/lectures-nbconvert.tpl"
 #make website
 jupyter_make_site = True
 
-#serial execution flags
-jupyter_threads_per_worker=1
-jupyter_number_workers=1


### PR DESCRIPTION
This PR adds a method to compile using 4 cores which seems robust to ZMQ issues for local builds. This greatly speeds up compilation from the new default for serial execution. 

Removes serial execution from `conf.py` file as it is now the default behaviour in the extension. 