### PR TITLE
Coverage reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 _build/
 _build_website/
+_build_coverage/
 .DS_Store
 **/.ipynb_checkpoints/
 **/*.ipynb

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ SPHINXPROJ    = lecture-source-jl
 SOURCEDIR     = source/rst
 BUILDDIR      = _build
 CORES 		  = 4
-BUILDCOVERAGE = _build/jupyter/coverage
+BUILDCOVERAGE = _build_coverage
 
 
 # Put it first so that "make" without argument is like "make help".
@@ -32,8 +32,11 @@ preview:
 jupyter-parallel:
 	@$(SPHINXBUILD) -M jupyter "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) -D jupyter_number_workers=$(CORES)
 
-coverage: 
-	@$(SPHINXBUILD) -M jupyter "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) -D jupyter_make_coverage=1 -D jupyter_make_site=0 -D jupyter_generate_html=0 -D jupyter_ignore_skip_test=0 -D jupyter_drop_tests=0
+clean-coverage:
+	rm -rf $(BUILDCOVERAGE)
+
+coverage: clean-coverage
+	@$(SPHINXBUILD) -M jupyter "$(SOURCEDIR)" "$(BUILDCOVERAGE)" $(SPHINXOPTS) $(O) -D jupyter_make_coverage=1 -D jupyter_make_site=0 -D jupyter_generate_html=0 -D jupyter_ignore_skip_test=0 -D jupyter_drop_tests=0 -D jupyter_download_nb=0
 
 
 # Catch-all target: route all unknown targets to Sphinx using the new

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,8 @@ clean-coverage:
 coverage: clean-coverage
 	@$(SPHINXBUILD) -M jupyter "$(SOURCEDIR)" "$(BUILDCOVERAGE)" $(SPHINXOPTS) $(O) -D jupyter_make_coverage=1 -D jupyter_make_site=0 -D jupyter_generate_html=0 -D jupyter_ignore_skip_test=0 -D jupyter_drop_tests=0 -D jupyter_download_nb=0
 
+coverage-parallel: clean-coverage
+	@$(SPHINXBUILD) -M jupyter "$(SOURCEDIR)" "$(BUILDCOVERAGE)" $(SPHINXOPTS) $(O) -D jupyter_make_coverage=1 -D jupyter_make_site=0 -D jupyter_generate_html=0 -D jupyter_ignore_skip_test=0 -D jupyter_drop_tests=0 -D jupyter_download_nb=0 -D jupyter_number_workers=$(CORES)
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).


### PR DESCRIPTION
Makefile changes for coverage reports - added 
1)  `coverage`  - for creating coverage reports
2) `coverage-parallel` - for running coverage reports in parallel 
3) `clean-coverage` - for cleaning up the coverage folder