### PR TITLE
FEAT: Adding language specific path to status link

### DIFF
--- a/theme/templates/lectures-nbconvert.tpl
+++ b/theme/templates/lectures-nbconvert.tpl
@@ -126,7 +126,7 @@
 
 		        	<div class="header-search"><gcse:searchbox-only></gcse:searchbox-only></div>
 
-		        	<p id="combined_percentage" class="combined-coverage"><a href="/status.html"></a></p>
+		        	<p id="combined_percentage" class="combined-coverage"><a href="/{{nb_lang}}/status.html"></a></p>
 
 				</div>
 
@@ -159,7 +159,7 @@
 								<li><a href="/{{nb_lang}}/_downloads/ipynb/{{nb_filename_with_path}}.ipynb"><img src="/_static/img/jupyter-notebook-download-blue.svg" id="notebook_download_badge"></a></li>
 								<li><a href="/_downloads/pdf/py/{{nb_filename_with_path}}.pdf"><img src="/_static/img/pdf-download-blue.svg" id="pdf_download_badge"></a></li>
 							{% endif %}
-							<li><a href="/status.html"><img src="https://img.shields.io/badge/Execution%20test-not%20available-lightgrey.svg" id="executability_status_badge"></a></li>
+							<li><a href="/{{nb_lang}}/status.html"><img src="https://img.shields.io/badge/Execution%20test-not%20available-lightgrey.svg" id="executability_status_badge"></a></li>
 						</ul>
 
 						<div class="how-to">
@@ -180,7 +180,7 @@
 								<li><a href="/{{nb_lang}}/_downloads/ipynb/{{nb_filename_with_path}}.ipynb"><img src="/_static/img/jupyter-notebook-download-blue.svg" id="notebook_download_badge"></a></li>
 								<li><a href="/_downloads/pdf/jl/{{nb_filename_with_path}}.pdf"><img src="/_static/img/pdf-download-blue.svg" id="pdf_download_badge"></a></li>
 							{% endif %}
-							<li><a href="/status.html"><img src="https://img.shields.io/badge/Execution%20test-not%20available-lightgrey.svg" id="executability_status_badge"></a></li>
+							<li><a href="/{{nb_lang}}/status.html"><img src="https://img.shields.io/badge/Execution%20test-not%20available-lightgrey.svg" id="executability_status_badge"></a></li>
 						</ul>
 						
 						<div class="how-to">


### PR DESCRIPTION
Status badge (Total coverage button below) will now point to the local status report instead of the global one.

![image](https://user-images.githubusercontent.com/6542997/60571544-2eb99100-9db7-11e9-998a-b6b25c7963ed.png)
