### PR TITLE
FEAT: Make commands for better user experience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 _build/
 _build_website/
 _build_coverage/
+dask-worker-space/
 .DS_Store
 **/.ipynb_checkpoints/
 **/*.ipynb

--- a/Makefile
+++ b/Makefile
@@ -7,24 +7,22 @@ SPHINXBUILD   = python -msphinx
 SPHINXPROJ    = lecture-source-jl
 SOURCEDIR     = source/rst
 BUILDDIR      = _build
+BUILDWEBSITE  = _build_website
 CORES 		  = 4
 BUILDCOVERAGE = _build_coverage
 
-
 # Put it first so that "make" without argument is like "make help".
-setup:
-	cd source/rst && ln -s ../_static _static
-
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 .PHONY: help Makefile
 
+# Install requiremenets for building lectures.
 setup:
 	pip install -r requirements.txt
 
 preview:
-ifeq ($(target), website)
+ifneq (,$(filter $(target),website Website))
 	cd _build/jupyter_html/ && python -m http.server
 else
 ifdef lecture
@@ -37,22 +35,28 @@ endif
 clean-coverage:
 	rm -rf $(BUILDCOVERAGE)
 
-coverage: clean-coverage
-ifeq ($(parallel), True)
-	@$(SPHINXBUILD) -M jupyter "$(SOURCEDIR)" "$(BUILDCOVERAGE)" $(SPHINXOPTS) $(O) -D jupyter_make_coverage=1 -D jupyter_execute_notebooks=1 -D jupyter_ignore_skip_test=0 -D jupyter_number_workers=$(CORES)
+clean-website:
+	rm -rf $(BUILDWEBSITE)
+
+coverage:
+ifneq (,$(filter $(parallel),true True))
+	@$(SPHINXBUILD) -M jupyter "$(SOURCEDIR)" "$(BUILDCOVERAGE)" $(SPHINXOPTS) $(O) -D jupyter_make_coverage=1 -D jupyter_execute_notebooks=1 -D jupyter_ignore_skip_test=0 -D jupyter_template_coverage_file_path="theme/templates/error_report_template.html" -D jupyter_number_workers=$(CORES)
 else
-	@$(SPHINXBUILD) -M jupyter "$(SOURCEDIR)" "$(BUILDCOVERAGE)" $(SPHINXOPTS) $(O) -D jupyter_make_coverage=1 -D jupyter_execute_notebooks=1 -D jupyter_ignore_skip_test=0
+	@$(SPHINXBUILD) -M jupyter "$(SOURCEDIR)" "$(BUILDCOVERAGE)" $(SPHINXOPTS) $(O) -D jupyter_make_coverage=1 -D jupyter_execute_notebooks=1 -D jupyter_ignore_skip_test=0 -D jupyter_template_coverage_file_path="theme/templates/error_report_template.html"
 endif
 
-website: clean
-ifeq ($(parallel), True)
-	@$(SPHINXBUILD) -M jupyter "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) -D jupyter_make_site=1 -D jupyter_generate_html=1 -D jupyter_download_nb=1 -D jupyter_execute_notebooks=1 -D jupyter_number_workers=$(CORES)
+website:
+ifneq (,$(filter $(parallel),true True))
+	@$(SPHINXBUILD) -M jupyter "$(SOURCEDIR)" "$(BUILDWEBSITE)" $(SPHINXOPTS) $(O) -D jupyter_make_site=1 -D jupyter_generate_html=1 -D jupyter_download_nb=1 -D jupyter_execute_notebooks=1 -D jupyter_target_html=1 -D jupyter_images_urlpath="https://s3-ap-southeast-2.amazonaws.com/lectures.quantecon.org/py/_static/" -D jupyter_images_markdown=0 -D jupyter_html_template="theme/templates/lectures-nbconvert.tpl" -D jupyter_download_nb_urlpath="https://lectures.quantecon.org/" -D jupyter_coverage_dir=$(BUILDCOVERAGE) -D jupyter_number_workers=$(CORES)
+
 else
-	@$(SPHINXBUILD) -M jupyter "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) -D jupyter_make_site=1 -D jupyter_generate_html=1 -D jupyter_download_nb=1 -D jupyter_execute_notebooks=1
+	@$(SPHINXBUILD) -M jupyter "$(SOURCEDIR)" "$(BUILDWEBSITE)" $(SPHINXOPTS) $(O) -D jupyter_make_site=1 -D jupyter_generate_html=1 -D jupyter_download_nb=1 -D jupyter_execute_notebooks=1 -D jupyter_target_html=1 -D jupyter_images_urlpath="https://s3-ap-southeast-2.amazonaws.com/lectures.quantecon.org/py/_static/" -D jupyter_images_markdown=0 -D jupyter_html_template="theme/templates/lectures-nbconvert.tpl" -D jupyter_download_nb_urlpath="https://lectures.quantecon.org/" -D jupyter_coverage_dir=$(BUILDCOVERAGE)
 endif
+
+notebooks:
+	make jupyter
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) -D jupyter_images_urlpath=0 -D jupyter_images_markdown=1
-
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) -D jupyter_allow_html_only=1

--- a/Makefile
+++ b/Makefile
@@ -20,29 +20,39 @@ help:
 
 .PHONY: help Makefile
 
-jupyter:
-	@$(SPHINXBUILD) -M jupyter "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
-
-jupyter-tests:
-	@$(SPHINXBUILD) -M jupyter "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) -D jupyter_drop_tests=0
+setup:
+	pip install -r requirements.txt
 
 preview:
+ifeq ($(target), website)
 	cd _build/jupyter_html/ && python -m http.server
-
-jupyter-parallel:
-	@$(SPHINXBUILD) -M jupyter "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) -D jupyter_number_workers=$(CORES)
+else
+ifdef lecture
+	cd _build/jupyter/ && jupyter notebook $(basename $(lecture)).ipynb
+else
+	cd _build/jupyter/ && jupyter notebook
+endif
+endif
 
 clean-coverage:
 	rm -rf $(BUILDCOVERAGE)
 
 coverage: clean-coverage
-	@$(SPHINXBUILD) -M jupyter "$(SOURCEDIR)" "$(BUILDCOVERAGE)" $(SPHINXOPTS) $(O) -D jupyter_make_coverage=1 -D jupyter_make_site=0 -D jupyter_generate_html=0 -D jupyter_ignore_skip_test=0 -D jupyter_drop_tests=0 -D jupyter_download_nb=0
+ifeq ($(parallel), True)
+	@$(SPHINXBUILD) -M jupyter "$(SOURCEDIR)" "$(BUILDCOVERAGE)" $(SPHINXOPTS) $(O) -D jupyter_make_coverage=1 -D jupyter_execute_notebooks=1 -D jupyter_ignore_skip_test=0 -D jupyter_number_workers=$(CORES)
+else
+	@$(SPHINXBUILD) -M jupyter "$(SOURCEDIR)" "$(BUILDCOVERAGE)" $(SPHINXOPTS) $(O) -D jupyter_make_coverage=1 -D jupyter_execute_notebooks=1 -D jupyter_ignore_skip_test=0
+endif
 
-coverage-parallel: clean-coverage
-	@$(SPHINXBUILD) -M jupyter "$(SOURCEDIR)" "$(BUILDCOVERAGE)" $(SPHINXOPTS) $(O) -D jupyter_make_coverage=1 -D jupyter_make_site=0 -D jupyter_generate_html=0 -D jupyter_ignore_skip_test=0 -D jupyter_drop_tests=0 -D jupyter_download_nb=0 -D jupyter_number_workers=$(CORES)
+website: clean
+ifeq ($(parallel), True)
+	@$(SPHINXBUILD) -M jupyter "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) -D jupyter_make_site=1 -D jupyter_generate_html=1 -D jupyter_download_nb=1 -D jupyter_execute_notebooks=1 -D jupyter_number_workers=$(CORES)
+else
+	@$(SPHINXBUILD) -M jupyter "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) -D jupyter_make_site=1 -D jupyter_generate_html=1 -D jupyter_download_nb=1 -D jupyter_execute_notebooks=1
+endif
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) -D jupyter_images_urlpath=0 -D jupyter_images_markdown=1
 

--- a/source/rst/conf.py
+++ b/source/rst/conf.py
@@ -408,36 +408,42 @@ jupyter_headers = {
 # Filename for the file containing the welcome block
 jupyter_welcome_block = ""
 
-#Allow .. only:: html pass through
-jupyter_allow_html_only = True
+#Adjust links to target html (rather than ipynb)
+jupyter_target_html = False
 
-#path to download notebooks from
-jupyter_download_nb_urlpath = "https://lectures.quantecon.org/"
+#path to download notebooks from 
+jupyter_download_nb_urlpath = None
 
 #allow downloading of notebooks
-jupyter_download_nb = True
-
-#Adjust links to target html (rather than ipynb) when targeting html through nbconvert
-jupyter_target_html = True
-
-#Drop Tests Embedded in Lectures
-jupyter_drop_tests = True
+jupyter_download_nb = False
 
 #Use urlprefix images
-jupyter_images_urlpath = "https://s3-ap-southeast-2.amazonaws.com/lectures.quantecon.org/jl/_static/"
+jupyter_images_urlpath = None
+
+#Allow ipython as a language synonym for blocks to be ipython highlighted
+jupyter_lang_synonyms = ["ipython"]
+
+#Execute skip-test code blocks for rendering of website (this will need to be ignored in coverage testing)
+jupyter_ignore_skip_test = True
 
 #allow execution of notebooks
-jupyter_execute_notebooks = True
+jupyter_execute_notebooks = False
 
 # Location of template folder for coverage reports
-jupyter_template_coverage_file_path = "theme/templates/error_report_template.html"
+jupyter_template_coverage_file_path = False
 
 # generate html from IPYNB files
-jupyter_generate_html = True
+jupyter_generate_html = False
 
 # html template specific to your website needs
-jupyter_html_template = "theme/templates/lectures-nbconvert.tpl"
+jupyter_html_template = None
 
 #make website
-jupyter_make_site = True
+jupyter_make_site = False
+
+#force markdown image inclusion
+jupyter_images_markdown = True
+
+#This is set true by default to pass html to the notebooks
+jupyter_allow_html_only=True
 


### PR DESCRIPTION
 Make command structure in this PR :-

`make setup` - installs the dependencies

`make jupyter` - converts rst to ipynb (unexecuted)

`make website` - converts rst to website (along with execution and conversion to html)

`make website parallel=True` - parallel version of make website

`make preview` - opens the unexecuted notebook folder (_build/jupyter)

`make preview lecture=code_blocks` - opens the unexecuted lecture (code_blocks.ipynb in this case)

`make preview target=website` -creates a python server and serves the _build/jupyter_html folder

This PR will rework the default settings in the conf.py file to enable make jupyter to focus on building local notebooks. The settings required for build the website will be enabled using override flags from the cmd line built into the make website command.

We have also added separate build pathways. Local editing notebooks will remain in _build. The files used for constructing the website including ipynb, executed, html, _static are all now contained in _build_website. The files used for coverage ipynb, executed-ipynb are in _build_coverage.