### PR TITLE
Adjust config for theme and template path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -c "./"
 SPHINXBUILD   = python -msphinx
 SPHINXPROJ    = lecture-source-jl
 SOURCEDIR     = source/rst

--- a/conf.py
+++ b/conf.py
@@ -377,7 +377,7 @@ jupyter_conversion_mode = "all"
 jupyter_write_metadata = False
 
 # Location for _static folder
-jupyter_static_file_path = ["_static"]
+jupyter_static_file_path = ["source/_static"]
 
 # default lang
 jupyter_default_lang = "julia"


### PR DESCRIPTION
This PR adjusts the configuration of `conf.py` and `Makefile` to correct the theme and template path. 

The `conf.py` file for the project was moved to the root level of the repository (which is the same as `lecture-source-py`) as we think that is a more logical location for it. The `source/rst` should now just contain the `rst` files. 