### PR TITLE
fix parallel interface with jupinx and allow integer specification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,6 @@ SPHINXPROJ    = lecture-source-jl
 SOURCEDIR     = source/rst
 BUILDDIR      = _build
 BUILDWEBSITE  = _build/website
-CORES 		  = 4
 BUILDCOVERAGE = _build/coverage
 FILES         = 
 
@@ -40,15 +39,15 @@ clean-website:
 	rm -rf $(BUILDWEBSITE)
 
 coverage:
-ifneq (,$(filter $(parallel),true True))
-	@$(SPHINXBUILD) -M jupyter "$(SOURCEDIR)" "$(BUILDCOVERAGE)" $(FILES) $(SPHINXOPTS) $(O) -D jupyter_make_coverage=1 -D jupyter_execute_notebooks=1 -D jupyter_drop_tests=0 -D jupyter_ignore_skip_test=0 -D jupyter_template_coverage_file_path="error_report_template.html" -D jupyter_number_workers=$(CORES)
+ifneq ($(strip $(parallel)),)
+	@$(SPHINXBUILD) -M jupyter "$(SOURCEDIR)" "$(BUILDCOVERAGE)" $(FILES) $(SPHINXOPTS) $(O) -D jupyter_make_coverage=1 -D jupyter_execute_notebooks=1 -D jupyter_drop_tests=0 -D jupyter_ignore_skip_test=0 -D jupyter_template_coverage_file_path="error_report_template.html" -D jupyter_number_workers=$(parallel)
 else
 	@$(SPHINXBUILD) -M jupyter "$(SOURCEDIR)" "$(BUILDCOVERAGE)" $(FILES) $(SPHINXOPTS) $(O) -D jupyter_make_coverage=1 -D jupyter_execute_notebooks=1 -D jupyter_drop_tests=0 -D jupyter_ignore_skip_test=0 -D jupyter_template_coverage_file_path="error_report_template.html"
 endif
 
 website:
-ifneq (,$(filter $(parallel),true True))
-	@$(SPHINXBUILD) -M jupyter "$(SOURCEDIR)" "$(BUILDWEBSITE)" $(FILES) $(SPHINXOPTS) $(O) -D jupyter_make_site=1 -D jupyter_generate_html=1 -D jupyter_download_nb=1 -D jupyter_execute_notebooks=1 -D jupyter_target_html=1 -D jupyter_download_nb_image_urlpath="https://s3-ap-southeast-2.amazonaws.com/lectures.quantecon.org/jl/_static/" -D jupyter_images_markdown=0 -D jupyter_html_template="julia.tpl" -D jupyter_download_nb_urlpath="https://lectures.quantecon.org/" -D jupyter_coverage_dir=$(BUILDCOVERAGE) -D jupyter_number_workers=$(CORES)
+ifneq ($(strip $(parallel)),)
+	@$(SPHINXBUILD) -M jupyter "$(SOURCEDIR)" "$(BUILDWEBSITE)" $(FILES) $(SPHINXOPTS) $(O) -D jupyter_make_site=1 -D jupyter_generate_html=1 -D jupyter_download_nb=1 -D jupyter_execute_notebooks=1 -D jupyter_target_html=1 -D jupyter_download_nb_image_urlpath="https://s3-ap-southeast-2.amazonaws.com/lectures.quantecon.org/jl/_static/" -D jupyter_images_markdown=0 -D jupyter_html_template="julia.tpl" -D jupyter_download_nb_urlpath="https://lectures.quantecon.org/" -D jupyter_coverage_dir=$(BUILDCOVERAGE) -D jupyter_number_workers=$(parallel)
 
 else
 	@$(SPHINXBUILD) -M jupyter "$(SOURCEDIR)" "$(BUILDWEBSITE)" $(FILES) $(SPHINXOPTS) $(O) -D jupyter_make_site=1 -D jupyter_generate_html=1 -D jupyter_download_nb=1 -D jupyter_execute_notebooks=1 -D jupyter_target_html=1 -D jupyter_download_nb_image_urlpath="https://s3-ap-southeast-2.amazonaws.com/lectures.quantecon.org/jl/_static/" -D jupyter_images_markdown=0 -D jupyter_html_template="julia.tpl" -D jupyter_download_nb_urlpath="https://lectures.quantecon.org/" -D jupyter_coverage_dir=$(BUILDCOVERAGE)

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ There are a few different targets, notably:
 
 ### Options and Special Cases
 
-Specifying parallel execution (i.e., `make coverage -e parallel=True`) will use 4 cores instead of 1. This leads to a notable speedup in build times. 
+Specifying parallel execution (i.e., `make coverage parallel=8`) will use 8 cores instead of 1. This leads to a notable speedup in build times. (There are some [`zmq` errors](https://github.com/QuantEcon/sphinxcontrib-jupyter/issues/261) that sporadically pop up at very high core counts, i.e. above 8.)
 
 You can build only a few notebooks by [**FILL IN PROCEDURE HERE**]
 


### PR DESCRIPTION
This PR allows you to specify the number of workers rather than `True/False` to trigger parallel builds.

```
jupinx -cws --parallel=8
```

or 

```
make website parallel=8
```