### PR TITLE
FIX: Adding _static for image paths

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -377,7 +377,7 @@ jupyter_conversion_mode = "all"
 jupyter_write_metadata = False
 
 # Location for _static folder
-jupyter_static_file_path = ["source/_static"]
+jupyter_static_file_path = ["source/_static", "_static"]
 
 # default lang
 jupyter_default_lang = "julia"


### PR DESCRIPTION
`_static` added to the `jupyter_static_file_path` as the images have that path. 