### PR TITLE
fixed exercise 1 solution indexing

### DIFF
--- a/source/rst/dynamic_programming/mccall_model.rst
+++ b/source/rst/dynamic_programming/mccall_model.rst
@@ -617,7 +617,7 @@ Here's one solution
         @assert length(w) - 1 ∈ support(dist) && w̄ <= w[end]
         while true
             # Generate a wage draw
-            w_val = w[rand(dist)] # the wage dist set up earlier
+            w_val = w[rand(dist)+1] # the wage dist set up earlier
             if w_val ≥ w̄
                 stopping_time = t
                 break


### PR DESCRIPTION
Fixes indexing when generating random wages ([879](https://github.com/QuantEcon/lecture-source-jl/issues/879)).